### PR TITLE
Refactor (some) auth components

### DIFF
--- a/src/components/Auth.js
+++ b/src/components/Auth.js
@@ -4,9 +4,13 @@ import Alert from '@material-ui/lab/Alert'
 import AuthForm from './AuthForm'
 import AuthSocial from './AuthSocial'
 import { useAuthForm } from '../hooks/use-auth-form.hook'
+import { useAuthTypeOptions } from '../hooks/use-auth-type-options.hook'
+import { PROVIDERS } from '../constants/providers'
+import { AUTH_ROUTE_TYPES } from '../constants/route-types'
 
-function Auth({ buttonAction, providers }) {
-  const { formAlert, handleAuth, handleFormAlert, type } = useAuthForm()
+function Auth() {
+  const { formAlert, handleAuth, handleFormAlert } = useAuthForm()
+  const { options, type } = useAuthTypeOptions()
 
   return (
     <>
@@ -18,21 +22,21 @@ function Auth({ buttonAction, providers }) {
 
       <AuthForm
         type={type}
-        buttonAction={buttonAction}
+        buttonAction={options.buttonAction}
         onAuth={handleAuth}
         onFormAlert={handleFormAlert}
       />
 
-      {['signup', 'signin'].includes(type) && (
+      {AUTH_ROUTE_TYPES.includes(type) && (
         <>
-          {providers && providers.length && (
+          {PROVIDERS && PROVIDERS.length && (
             <>
               <Box textAlign="center" fontSize={12} my={2}>
                 OR
               </Box>
               <AuthSocial
-                buttonAction={buttonAction}
-                providers={providers}
+                buttonAction={options.buttonAction}
+                providers={PROVIDERS}
                 showLastUsed={true}
                 onAuth={handleAuth}
                 onError={(message) => {

--- a/src/components/Auth.test.js
+++ b/src/components/Auth.test.js
@@ -2,23 +2,24 @@ import * as React from 'react'
 import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { useAuthForm } from '../hooks/use-auth-form.hook'
+import { useAuthTypeOptions } from '../hooks/use-auth-type-options.hook'
 import Auth from './Auth'
 
-const mockProps = {
-  buttonAction: jest.fn(),
-  providers: ['google', 'facebook'],
-}
 const mockUseAuthFormReturn = {
   formAlert: null,
   handleAuth: jest.fn(),
   handleFormAlert: jest.fn(),
   type: 'signin',
 }
+const mockUseAuthTypeOptionsReturn = {
+  type: 'signin',
+  options: {},
+}
 
 jest.mock('../hooks/use-auth-form.hook')
+jest.mock('../hooks/use-auth-type-options.hook')
 
 jest.mock('./AuthForm', () => () => <div data-testid="auth-form" />)
-
 jest.mock('./AuthSocial', () => () => <div data-testid="auth-social" />)
 
 describe('Auth component', () => {
@@ -26,7 +27,9 @@ describe('Auth component', () => {
 
   it('passes basic a11y testing', async () => {
     useAuthForm.mockImplementation(() => mockUseAuthFormReturn)
-    const { container } = render(<Auth {...mockProps} />)
+    useAuthTypeOptions.mockImplementation(() => mockUseAuthTypeOptionsReturn)
+
+    const { container } = render(<Auth />)
 
     const results = await axe(container)
     expect(results).toHaveNoViolations()
@@ -34,26 +37,22 @@ describe('Auth component', () => {
 
   it('renders AuthForm and AuthSocial child components', () => {
     useAuthForm.mockImplementation(() => mockUseAuthFormReturn)
-    render(<Auth {...mockProps} />)
+    useAuthTypeOptions.mockImplementation(() => mockUseAuthTypeOptionsReturn)
+
+    render(<Auth />)
 
     expect(screen.getByTestId('auth-form')).toBeInTheDocument()
     expect(screen.getByTestId('auth-social')).toBeInTheDocument()
   })
 
   it('does not render AuthSocial if type is not signin or signup', () => {
-    useAuthForm.mockImplementation(() => ({
-      ...mockUseAuthFormReturn,
+    useAuthForm.mockImplementation(() => mockUseAuthFormReturn)
+    useAuthTypeOptions.mockImplementation(() => ({
+      ...mockUseAuthTypeOptionsReturn,
       type: 'foobar',
     }))
-    render(<Auth {...mockProps} />)
 
-    expect(screen.getByTestId('auth-form')).toBeInTheDocument()
-    expect(screen.queryByTestId('auth-social')).not.toBeInTheDocument()
-  })
-
-  it('does not render AuthSocial if providers array is empty', () => {
-    useAuthForm.mockImplementation(() => mockUseAuthFormReturn)
-    render(<Auth {...mockProps} providers={[]} />)
+    render(<Auth />)
 
     expect(screen.getByTestId('auth-form')).toBeInTheDocument()
     expect(screen.queryByTestId('auth-social')).not.toBeInTheDocument()
@@ -61,6 +60,7 @@ describe('Auth component', () => {
 
   it('displays error message when formAlert is set', () => {
     const errorMessage = 'There is a great big error all up in here'
+
     useAuthForm.mockImplementation(() => ({
       ...mockUseAuthFormReturn,
       formAlert: {
@@ -68,7 +68,9 @@ describe('Auth component', () => {
         message: errorMessage,
       },
     }))
-    render(<Auth {...mockProps} />)
+    useAuthTypeOptions.mockImplementation(() => mockUseAuthTypeOptionsReturn)
+
+    render(<Auth />)
 
     expect(screen.getByTestId('auth-form-alert')).toHaveTextContent(
       errorMessage,

--- a/src/components/AuthFooter.js
+++ b/src/components/AuthFooter.js
@@ -3,6 +3,9 @@ import Box from '@material-ui/core/Box'
 import LinkMui from '@material-ui/core/Link'
 import { makeStyles } from '@material-ui/core/styles'
 import { Link } from './../util/router'
+import { useAuthTypeOptions } from '../hooks/use-auth-type-options.hook'
+import { ROUTE_TYPES } from '../constants/route-types'
+import { ROUTES } from '../constants/routing'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -22,58 +25,61 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-function AuthFooter(props) {
+function AuthFooter() {
   const classes = useStyles()
+  const { type, options } = useAuthTypeOptions()
+
+  if (!options.showFooter) return null
 
   return (
     <div className={classes.root}>
-      {props.type === 'signup' && (
+      {type === ROUTES.SIGNIN && (
         <>
-          {props.showAgreement && (
+          {options.showAgreement && (
             <Box mb={2}>
               By signing up, you are agreeing to our{' '}
-              <LinkMui component={Link} to={props.termsPath}>
+              <LinkMui component={Link} to={options.termsPath}>
                 Terms of Service
               </LinkMui>{' '}
               and{' '}
-              <LinkMui component={Link} to={props.privacyPolicyPath}>
+              <LinkMui component={Link} to={options.privacyPolicyPath}>
                 Privacy Policy
               </LinkMui>
               .
             </Box>
           )}
 
-          {props.signinText}
+          {options.signinText}
           <span className={classes.spacerSmall} />
-          <LinkMui component={Link} to={props.signinPath}>
-            {props.signinAction}
+          <LinkMui component={Link} to={options.signinPath}>
+            {options.signinAction}
           </LinkMui>
         </>
       )}
 
-      {props.type === 'signin' && (
+      {type === ROUTE_TYPES.SIGNIN && (
         <>
-          <LinkMui component={Link} to={props.signupPath}>
-            {props.signupAction}
+          <LinkMui component={Link} to={options.signupPath}>
+            {options.signupAction}
           </LinkMui>
 
-          {props.forgotPassAction && (
+          {options.forgotPassAction && (
             <>
               <span className={classes.spacerMedium} />
-              <LinkMui component={Link} to={props.forgotPassPath}>
-                {props.forgotPassAction}
+              <LinkMui component={Link} to={options.forgotPassPath}>
+                {options.forgotPassAction}
               </LinkMui>
             </>
           )}
         </>
       )}
 
-      {props.type === 'forgotpass' && (
+      {type === ROUTE_TYPES.FORGOT && (
         <>
-          {props.signinText}
+          {options.signinText}
           <span className={classes.spacerSmall} />
-          <LinkMui component={Link} to={props.signinPath}>
-            {props.signinAction}
+          <LinkMui component={Link} to={options.signinPath}>
+            {options.signinAction}
           </LinkMui>
         </>
       )}

--- a/src/components/AuthSection.js
+++ b/src/components/AuthSection.js
@@ -4,60 +4,17 @@ import Section from './Section'
 import SectionHeader from './SectionHeader'
 import Auth from './Auth'
 import AuthFooter from './AuthFooter'
+import { useAuthTypeOptions } from '../hooks/use-auth-type-options.hook'
 
-function AuthSection(props) {
-  // Options by auth type
-  const optionsByType = {
-    signup: {
-      // Top Title
-      title: 'Get yourself an account',
-      // Button text
-      buttonAction: 'Sign up',
-      // Footer text and links
-      showFooter: true,
-      signinText: 'Already have an account?',
-      signinAction: 'Sign in',
-      signinPath: '/auth/signin',
-      // Terms and privacy policy agreement
-      showAgreement: true,
-      termsPath: '/legal/terms-of-service',
-      privacyPolicyPath: '/legal/privacy-policy',
-    },
-    signin: {
-      title: 'Welcome back',
-      buttonAction: 'Sign in',
-      showFooter: true,
-      signupAction: 'Create an account',
-      signupPath: '/auth/signup',
-      forgotPassAction: 'Forgot Password?',
-      forgotPassPath: '/auth/forgotpass',
-    },
-    forgotpass: {
-      title: 'Get a new password',
-      buttonAction: 'Reset password',
-      showFooter: true,
-      signinText: 'Remember it after all?',
-      signinAction: 'Sign in',
-      signinPath: '/auth/signin',
-    },
-    changepass: {
-      title: 'Choose a new password',
-      buttonAction: 'Change password',
-    },
-  }
-
-  // Ensure we have a valid auth type
-  const type = optionsByType[props.type] ? props.type : 'signup'
-
-  // Get options object for current auth type
-  const options = optionsByType[type]
+function AuthSection({ bgColor, bgImage, bgImageOpacity, size }) {
+  const { options, type } = useAuthTypeOptions()
 
   return (
     <Section
-      bgColor={props.bgColor}
-      size={props.size}
-      bgImage={props.bgImage}
-      bgImageOpacity={props.bgImageOpacity}
+      bgColor={bgColor}
+      size={size}
+      bgImage={bgImage}
+      bgImageOpacity={bgImageOpacity}
     >
       <Container maxWidth="xs">
         <SectionHeader
@@ -66,15 +23,8 @@ function AuthSection(props) {
           size={4}
           textAlign="center"
         />
-        <Auth
-          type={type}
-          buttonAction={options.buttonAction}
-          providers={props.providers}
-          afterAuthPath={props.afterAuthPath}
-          key={type}
-        />
-
-        {options.showFooter && <AuthFooter type={type} {...options} />}
+        <Auth />
+        <AuthFooter />
       </Container>
     </Section>
   )

--- a/src/components/AuthSection.js
+++ b/src/components/AuthSection.js
@@ -7,7 +7,7 @@ import AuthFooter from './AuthFooter'
 import { useAuthTypeOptions } from '../hooks/use-auth-type-options.hook'
 
 function AuthSection({ bgColor, bgImage, bgImageOpacity, size }) {
-  const { options, type } = useAuthTypeOptions()
+  const { options } = useAuthTypeOptions()
 
   return (
     <Section

--- a/src/constants/providers.js
+++ b/src/constants/providers.js
@@ -1,0 +1,4 @@
+export const PROVIDER_GOOGLE = 'google'
+export const PROVIDER_FACEBOOK = 'facebook'
+
+export const PROVIDERS = [PROVIDER_GOOGLE, PROVIDER_FACEBOOK]

--- a/src/constants/route-types.js
+++ b/src/constants/route-types.js
@@ -1,0 +1,10 @@
+export const ROUTE_TYPE_SIGNUP = 'signup'
+export const ROUTE_TYPE_SIGNIN = 'signin'
+
+export const ROUTE_TYPES = {
+  SIGNUP: ROUTE_TYPE_SIGNUP,
+  SIGNIN: ROUTE_TYPE_SIGNIN,
+  FORGOT: 'forgotpass',
+}
+
+export const AUTH_ROUTE_TYPES = [ROUTE_TYPE_SIGNUP, ROUTE_TYPE_SIGNIN]

--- a/src/constants/route-types.js
+++ b/src/constants/route-types.js
@@ -5,6 +5,7 @@ export const ROUTE_TYPES = {
   SIGNUP: ROUTE_TYPE_SIGNUP,
   SIGNIN: ROUTE_TYPE_SIGNIN,
   FORGOT: 'forgotpass',
+  CHANGE: 'changepass',
 }
 
 export const AUTH_ROUTE_TYPES = [ROUTE_TYPE_SIGNUP, ROUTE_TYPE_SIGNIN]

--- a/src/constants/routing.js
+++ b/src/constants/routing.js
@@ -1,0 +1,8 @@
+export const ROUTES = {
+  DASHBOARD: '/dashboard',
+  SIGNIN: '/auth/signin',
+  SIGNUP: '/auth/signup',
+  FORGOT: '/auth/forgotpass',
+  TERMS: '/legal/terms-of-service',
+  PRIVACY: '/legal/privacy-policy',
+}

--- a/src/hooks/use-after-auth-path.hook.js
+++ b/src/hooks/use-after-auth-path.hook.js
@@ -1,0 +1,9 @@
+import { ROUTES } from '../constants/routing'
+import { useRouter } from '../util/router'
+
+export const useAfterAuthPath = () => {
+  const { query } = useRouter()
+  const afterAuthPath = query.next || ROUTES.DASHBOARD
+
+  return { afterAuthPath }
+}

--- a/src/hooks/use-after-auth-path.test.js
+++ b/src/hooks/use-after-auth-path.test.js
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { ROUTES } from '../constants/routing'
+import { useRouter } from '../util/router'
+import { useAfterAuthPath } from './use-after-auth-path.hook'
+
+jest.mock('../util/router')
+
+describe('useAfterAuthPath hook', () => {
+  it('returns router query.next value by default', () => {
+    useRouter.mockImplementation(() => ({
+      query: {
+        next: 'foo',
+      },
+    }))
+    const { result } = renderHook(() => useAfterAuthPath())
+
+    expect(result.current.afterAuthPath).toBe('foo')
+  })
+
+  it('returns dashboard route if next query.next is not set', () => {
+    useRouter.mockImplementation(() => ({
+      query: {
+        next: null,
+      },
+    }))
+    const { result } = renderHook(() => useAfterAuthPath())
+
+    expect(result.current.afterAuthPath).toBe(ROUTES.DASHBOARD)
+  })
+})

--- a/src/hooks/use-auth-form.hook.js
+++ b/src/hooks/use-auth-form.hook.js
@@ -1,20 +1,14 @@
 import { useState } from 'react'
 import { useRouter } from '../util/router'
+import { useAfterAuthPath } from './use-after-auth-path.hook'
 
 export const useAuthForm = () => {
-  const router = useRouter()
+  const { push } = useRouter()
+  const { afterAuthPath } = useAfterAuthPath()
   const [formAlert, setFormAlert] = useState(null)
 
-  const type = router.query.type
-  const afterAuthPath = router.query.next || '/dashboard'
+  const handleAuth = () => push(afterAuthPath)
+  const handleFormAlert = (data) => setFormAlert(data)
 
-  const handleAuth = () => {
-    router.push(afterAuthPath)
-  }
-
-  const handleFormAlert = (data) => {
-    setFormAlert(data)
-  }
-
-  return { formAlert, handleAuth, handleFormAlert, type }
+  return { formAlert, handleAuth, handleFormAlert }
 }

--- a/src/hooks/use-auth-form.test.js
+++ b/src/hooks/use-auth-form.test.js
@@ -16,13 +16,6 @@ const mockUseRouterReturn = {
 jest.mock('../util/router')
 
 describe('useAuthForm hook', () => {
-  it('returns type matching useRouter query.type', () => {
-    useRouter.mockImplementation(() => mockUseRouterReturn)
-    const { result } = renderHook(() => useAuthForm())
-
-    expect(result.current.type).toBe(mockQuery.type)
-  })
-
   it('returns null formAlert by default', () => {
     useRouter.mockImplementation(() => mockUseRouterReturn)
     const { result } = renderHook(() => useAuthForm())

--- a/src/hooks/use-auth-type-options.hook.js
+++ b/src/hooks/use-auth-type-options.hook.js
@@ -3,8 +3,8 @@ import { ROUTE_TYPES } from '../constants/route-types'
 import { ROUTES } from '../constants/routing'
 
 // Options by auth type
-const optionsByType = {
-  signup: {
+export const optionsByType = {
+  [ROUTE_TYPES.SIGNUP]: {
     // Top Title
     title: 'Get yourself an account',
     // Button text
@@ -19,7 +19,7 @@ const optionsByType = {
     termsPath: ROUTES.TERMS,
     privacyPolicyPath: ROUTES.PRIVACY,
   },
-  signin: {
+  [ROUTE_TYPES.SIGNIN]: {
     title: 'Welcome back',
     buttonAction: 'Sign in',
     showFooter: true,
@@ -28,7 +28,7 @@ const optionsByType = {
     forgotPassAction: 'Forgot Password?',
     forgotPassPath: ROUTES.FORGOT,
   },
-  forgotpass: {
+  [ROUTE_TYPES.FORGOT]: {
     title: 'Get a new password',
     buttonAction: 'Reset password',
     showFooter: true,
@@ -36,7 +36,7 @@ const optionsByType = {
     signinAction: 'Sign in',
     signinPath: ROUTES.SIGNIN,
   },
-  changepass: {
+  [ROUTE_TYPES.CHANGE]: {
     title: 'Choose a new password',
     buttonAction: 'Change password',
   },
@@ -49,6 +49,6 @@ export const useAuthTypeOptions = () => {
 
   return {
     type: validAuthType,
-    options: optionsByType[type],
+    options: optionsByType[validAuthType],
   }
 }

--- a/src/hooks/use-auth-type-options.hook.js
+++ b/src/hooks/use-auth-type-options.hook.js
@@ -1,0 +1,54 @@
+import { useRouteType } from './use-route-type.hook'
+import { ROUTE_TYPES } from '../constants/route-types'
+import { ROUTES } from '../constants/routing'
+
+// Options by auth type
+const optionsByType = {
+  signup: {
+    // Top Title
+    title: 'Get yourself an account',
+    // Button text
+    buttonAction: 'Sign up',
+    // Footer text and links
+    showFooter: true,
+    signinText: 'Already have an account?',
+    signinAction: 'Sign in',
+    signinPath: ROUTES.SIGNIN,
+    // Terms and privacy policy agreement
+    showAgreement: true,
+    termsPath: ROUTES.TERMS,
+    privacyPolicyPath: ROUTES.PRIVACY,
+  },
+  signin: {
+    title: 'Welcome back',
+    buttonAction: 'Sign in',
+    showFooter: true,
+    signupAction: 'Create an account',
+    signupPath: ROUTES.SIGNUP,
+    forgotPassAction: 'Forgot Password?',
+    forgotPassPath: ROUTES.FORGOT,
+  },
+  forgotpass: {
+    title: 'Get a new password',
+    buttonAction: 'Reset password',
+    showFooter: true,
+    signinText: 'Remember it after all?',
+    signinAction: 'Sign in',
+    signinPath: ROUTES.SIGNIN,
+  },
+  changepass: {
+    title: 'Choose a new password',
+    buttonAction: 'Change password',
+  },
+}
+
+export const useAuthTypeOptions = () => {
+  const { type } = useRouteType()
+
+  const validAuthType = optionsByType[type] ? type : ROUTE_TYPES.SIGNUP
+
+  return {
+    type: validAuthType,
+    options: optionsByType[type],
+  }
+}

--- a/src/hooks/use-auth-type-options.test.js
+++ b/src/hooks/use-auth-type-options.test.js
@@ -1,0 +1,34 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { ROUTE_TYPES } from '../constants/route-types'
+import { optionsByType, useAuthTypeOptions } from './use-auth-type-options.hook'
+import { useRouteType } from './use-route-type.hook'
+
+jest.mock('./use-route-type.hook')
+
+describe('useAuthTypeOptions hook', () => {
+  it('returns options object matching router type', () => {
+    useRouteType.mockImplementation(() => ({
+      type: ROUTE_TYPES.SIGNIN,
+    }))
+
+    const { result } = renderHook(() => useAuthTypeOptions())
+
+    expect(result.current.type).toBe(ROUTE_TYPES.SIGNIN)
+    expect(result.current.options).toStrictEqual(
+      optionsByType[ROUTE_TYPES.SIGNIN],
+    )
+  })
+
+  it('defaults to signup if router type is not set', () => {
+    useRouteType.mockImplementation(() => ({
+      type: '',
+    }))
+
+    const { result } = renderHook(() => useAuthTypeOptions())
+
+    expect(result.current.type).toBe(ROUTE_TYPES.SIGNUP)
+    expect(result.current.options).toStrictEqual(
+      optionsByType[ROUTE_TYPES.SIGNUP],
+    )
+  })
+})

--- a/src/hooks/use-route-type.hook.js
+++ b/src/hooks/use-route-type.hook.js
@@ -1,0 +1,9 @@
+import { useRouter } from '../util/router'
+
+export const useRouteType = () => {
+  const { query } = useRouter()
+
+  return {
+    type: query.type,
+  }
+}

--- a/src/hooks/use-route-type.hook.js
+++ b/src/hooks/use-route-type.hook.js
@@ -4,6 +4,6 @@ export const useRouteType = () => {
   const { query } = useRouter()
 
   return {
-    type: query.type,
+    type: query?.type || '',
   }
 }

--- a/src/hooks/use-route-type.test.js
+++ b/src/hooks/use-route-type.test.js
@@ -1,0 +1,31 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { useRouter } from '../util/router'
+import { useRouteType } from './use-route-type.hook'
+
+jest.mock('../util/router')
+
+describe('useRouteType hook', () => {
+  it('returns router query.type by default', () => {
+    useRouter.mockImplementation(() => ({
+      query: {
+        type: 'foo',
+      },
+    }))
+
+    const { result } = renderHook(() => useRouteType())
+
+    expect(result.current.type).toBe('foo')
+  })
+
+  it('returns empty string if query.type is not set', () => {
+    useRouter.mockImplementation(() => ({
+      query: {
+        type: null,
+      },
+    }))
+
+    const { result } = renderHook(() => useRouteType())
+
+    expect(result.current.type).toBe('')
+  })
+})

--- a/src/pages/auth.js
+++ b/src/pages/auth.js
@@ -1,11 +1,8 @@
 import React from 'react'
 import Meta from './../components/Meta'
 import AuthSection from './../components/AuthSection'
-import { useRouter } from './../util/router'
 
-function AuthPage(props) {
-  const router = useRouter()
-
+function AuthPage() {
   return (
     <>
       <Meta title="Auth" />
@@ -14,9 +11,6 @@ function AuthPage(props) {
         size="medium"
         bgImage=""
         bgImageOpacity={1}
-        type={router.query.type}
-        providers={['google', 'facebook']}
-        afterAuthPath={router.query.next || '/dashboard'}
       />
     </>
   )


### PR DESCRIPTION
## What's in this PR?

This PR starts at the `pages/auth.js` layer, refactoring `AuthSection`, `AuthFooter`, and `Auth` components to grab data from hooks rather than passing multiple layers of props. A few single-use and simpler custom hooks are added too, along with constants files. 

## Testing

- Pull down the branch
- Run `npm install`
- Run `npm start`
- Try the sign in, sign up, and forgot password pages and confirm nothing is wrong
- Try signing in and confirm nothing is wrong
- Run `npm run test`
- Confirm all tests run and pass