### PR TITLE
[TIG-408] Consistent headings across main pages

### DIFF
--- a/src/components/Browse/BrowseSection.js
+++ b/src/components/Browse/BrowseSection.js
@@ -11,6 +11,7 @@ import BrowseCategoryCarousel from './BrowseCategoryCarousel'
 
 import 'react-multi-carousel/lib/styles.css'
 import { useTranslation } from 'react-i18next'
+import { PageHeading } from 'components/PageHeading'
 
 function BrowseSection(props) {
   const [openSearchDrawer, setOpenSearchDrawer] = useState(false)
@@ -30,21 +31,11 @@ function BrowseSection(props) {
       bgImageOpacity={props.bgImageOpacity}
     >
       <Container sx={{ paddingBottom: '60px' }}>
-        <Box
-          sx={{
-            paddingTop: '40px',
-            paddingBottom: '7px',
-            display: 'flex',
-            flexDirection: 'row',
-            justifyContent: 'space-between',
-          }}
-        >
-          <Typography variant="h1">{t('browse.browse')}</Typography>
-
+        <PageHeading headingText={t('browse.browse')}>
           <IconButton onClick={() => setOpenSearchDrawer(true)}>
             <SearchIcon fontSize="large" />
           </IconButton>
-        </Box>
+        </PageHeading>
         <BrowseCategoryCarousel
           handleCategoryFilter={handleCategoryFilter}
           categoryFilter={categoryFilter}

--- a/src/components/CoursePage/CourseSection.js
+++ b/src/components/CoursePage/CourseSection.js
@@ -29,6 +29,7 @@ import { displayTime } from '../../util/timeHelpers'
 import CheckSimpleIcon from '@mui/icons-material/Check'
 import { useTranslation } from 'react-i18next'
 import CourseCreatingButtons from './CourseCreatingButtons'
+import { PageHeading } from 'components/PageHeading'
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props
@@ -128,26 +129,23 @@ function CourseSection({ data, courseData, courseProgress }) {
           }}
         >
           <IconButton
-            aria-label="close-icon"
+            aria-label="share course"
             onClick={() => setOpenShareDrawer(true)}
           >
             <ShareIcon sx={{ color: 'white' }} />
           </IconButton>
         </Box>
         {/* Series name */}
-        <Box sx={{ padding: '2em 2.5em' }}>
-          <Typography
-            variant="h1"
+        <Box sx={{ padding: '0 2.5em 2em' }}>
+          <PageHeading
+            headingText={courseData?.seriesName}
             textAlign="center"
-            color="#000"
-            sx={{ paddingBottom: { md: '20px' }, fontSize: { md: '2.75em' } }}
-          >
-            {courseData?.seriesName}
-          </Typography>
+            color="black"
+          />
 
           <CardMedia
             component="img"
-            alt={`${courseData.seriesName}-course`}
+            alt={courseData.seriesName}
             sx={{
               display: 'flex',
               alignItems: 'center',

--- a/src/components/CreatorSection.js
+++ b/src/components/CreatorSection.js
@@ -10,6 +10,7 @@ import InstagramIcon from '@mui/icons-material/Instagram'
 import Section from './Section'
 import CourseCard from './CourseCard'
 import ShareDrawer from './ShareDrawer'
+import { PageHeading } from './PageHeading'
 
 function CreatorSection({ coursesByCreator, creator }) {
   const [openShareDrawer, setOpenShareDrawer] = useState(false)
@@ -19,7 +20,7 @@ function CreatorSection({ coursesByCreator, creator }) {
       <Container>
         <Box sx={{display: {md: 'flex'}, gap: {md: '20px'}, paddingBottom: {md: '40px'}}}>
           <Box
-            alt={`creator-${creator.name}`}
+            alt={creator.name}
             component="img"
             width="100%"
             height={{
@@ -34,9 +35,7 @@ function CreatorSection({ coursesByCreator, creator }) {
             }
           />
           <Box>
-            <Typography variant="h5" sx={{ fontWeight: '700' }}>
-              {creator.name}
-            </Typography>
+            <PageHeading headingText={creator.name} m="0.25rem 0" />
             <Box
               sx={{
                 display: 'flex',

--- a/src/components/Dashboard/DashboardGreeting.js
+++ b/src/components/Dashboard/DashboardGreeting.js
@@ -1,55 +1,56 @@
 import React from 'react'
 import Typography from '@mui/material/Typography'
 import Box from '@mui/material/Box'
-import Stack from '@mui/material/Stack'
 import HandshakeIcon from '@mui/icons-material/Handshake'
 import { useTranslation } from 'react-i18next'
 
 import { useAuth } from '../../util/auth'
+import { PageHeading } from 'components/PageHeading'
+
+const greetingList = [
+  'Tansi',
+  'Aaniin',
+  'Ullaakuut',
+  'Boozhoo',
+  'Waachiyaa',
+  "Dänch'ea",
+]
+
+const getRandomGreeting = () =>
+  greetingList[Math.floor(Math.random() * greetingList.length)]
+
+const getUserGreetingText = (user, fallback) => {
+  const greetingText = []
+  greetingText.push(getRandomGreeting())
+
+  if (user?.displayName) greetingText.push(user?.displayName)
+  else if (user?.name) greetingText.push(user?.name)
+  else greetingText.push(fallback)
+
+  return greetingText.join(' ')
+}
 
 function DashboardGreeting(props) {
   const auth = useAuth()
   const { t } = useTranslation()
-
-  const greetingList = [
-    'Tansi',
-    'Aaniin',
-    'Ullaakuut',
-    'Boozhoo',
-    'Waachiyaa',
-    "Dänch'ea",
-  ]
-
-  const randomGreeting =
-    greetingList[Math.floor(Math.random() * greetingList.length)]
+  const headingText = getUserGreetingText(auth?.user, t('hello'))
 
   return (
-    <>
-      <Stack direction="row" spacing={1}>
-        <HandshakeIcon
-          fontSize="large"
-          sx={{
-            backgroundColor: '#0B0919',
-            padding: '5px',
-            borderRadius: '30%',
-            color: 'yellow',
-            alignSelf: 'center',
-          }}
-        />
-        <Typography variant="h1">{randomGreeting}</Typography>
-        <Box>
-        {auth.user ? (
-          <>
-            <Typography variant="h1">
-              {auth.user.displayName ?? auth.user.name}
-            </Typography>
-          </>
-        ) : (
-          <Typography variant="h1">{t('hello')}</Typography>
-        )}
-      </Box>
-      </Stack>
-    </>
+    <PageHeading
+      headingText={
+        <Box component="span" display="flex" alignItems="center" gap="0.35em">
+          <HandshakeIcon
+            alt=""
+            fontSize="large"
+            sx={{
+              backgroundColor: '#0B0919',
+              color: 'yellow',
+            }}
+          />
+          <Typography variant="span">{headingText}</Typography>
+        </Box>
+      }
+    />
   )
 }
 

--- a/src/components/MyCourses/MyCoursesSection.js
+++ b/src/components/MyCourses/MyCoursesSection.js
@@ -13,6 +13,7 @@ import MyCoursesDownloads from './MyCoursesDownloads'
 import MyCoursesWatchlistDrawer from './MyCoursesWatchlistDrawer'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../../util/auth'
+import { PageHeading } from 'components/PageHeading'
 
 function MyCoursesSection(props) {
   const { t } = useTranslation()
@@ -50,73 +51,69 @@ function MyCoursesSection(props) {
       bgImage={props.bgImage}
       bgImageOpacity={props.bgImageOpacity}
     >
-      <Box mt={2}>
-        <Container>
-          <Box sx={{ paddingBottom: '7px' }}>
-            <Typography variant="h4">{t('my-courses.my-courses')}</Typography>
-          </Box>
-          <Box>
-            <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-              <Tabs
-                value={tabIndex}
-                textColor="secondary"
-                indicatorColor="primary"
-                onChange={handleChangeTab}
-                aria-label="my courses tabs"
-                variant="fullWidth"
-              >
-                <Tab
-                  label={t('my-courses.my-progress')}
-                  {...a11yProps(0)}
-                  sx={{ color: 'white', padding: 0 }}
-                />
-                <Tab
-                  label={t('my-courses.downloads')}
-                  {...a11yProps(1)}
-                  sx={{ color: 'white' }}
-                />
-
-                <Tab
-                  label={t('my-courses.watchlist')}
-                  {...a11yProps(2)}
-                  sx={{ color: 'white' }}
-                />
-              </Tabs>
-            </Box>
-            <TabPanel tabIndex={tabIndex} index={0}>
-              <MyCoursesProgress
-                setSnackbarMessage={setSnackbarMessage}
-                setOpenSnackbar={setOpenSnackbar}
-              />
-            </TabPanel>
-            <TabPanel tabIndex={tabIndex} index={1}>
-              <MyCoursesDownloads />
-            </TabPanel>
-            <TabPanel tabIndex={tabIndex} index={2}>
-              <MyCoursesWatchlistDrawer
-                setSnackbarMessage={setSnackbarMessage}
-                setOpenSnackbar={setOpenSnackbar}
-                handleDownload={handleDownload}
-              />
-            </TabPanel>
-          </Box>
-          <Snackbar
-            open={openSnackbar}
-            autoHideDuration={6000}
-            onClose={() => setOpenSnackbar(false)}
-          >
-            <MuiAlert
-              elevation={6}
-              variant="filled"
-              onClose={() => setOpenSnackbar(false)}
-              severity={auth?.user ? 'success' : 'warning'}
-              sx={{ width: '100%' }}
+      <Container>
+        <PageHeading headingText={t('my-courses.my-courses')} />
+        <Box>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+            <Tabs
+              value={tabIndex}
+              textColor="secondary"
+              indicatorColor="primary"
+              onChange={handleChangeTab}
+              aria-label="my courses tabs"
+              variant="fullWidth"
             >
-              {snackbarMessage}
-            </MuiAlert>
-          </Snackbar>
-        </Container>
-      </Box>
+              <Tab
+                label={t('my-courses.my-progress')}
+                {...a11yProps(0)}
+                sx={{ color: 'white', padding: 0 }}
+              />
+              <Tab
+                label={t('my-courses.downloads')}
+                {...a11yProps(1)}
+                sx={{ color: 'white' }}
+              />
+
+              <Tab
+                label={t('my-courses.watchlist')}
+                {...a11yProps(2)}
+                sx={{ color: 'white' }}
+              />
+            </Tabs>
+          </Box>
+          <TabPanel tabIndex={tabIndex} index={0}>
+            <MyCoursesProgress
+              setSnackbarMessage={setSnackbarMessage}
+              setOpenSnackbar={setOpenSnackbar}
+            />
+          </TabPanel>
+          <TabPanel tabIndex={tabIndex} index={1}>
+            <MyCoursesDownloads />
+          </TabPanel>
+          <TabPanel tabIndex={tabIndex} index={2}>
+            <MyCoursesWatchlistDrawer
+              setSnackbarMessage={setSnackbarMessage}
+              setOpenSnackbar={setOpenSnackbar}
+              handleDownload={handleDownload}
+            />
+          </TabPanel>
+        </Box>
+        <Snackbar
+          open={openSnackbar}
+          autoHideDuration={6000}
+          onClose={() => setOpenSnackbar(false)}
+        >
+          <MuiAlert
+            elevation={6}
+            variant="filled"
+            onClose={() => setOpenSnackbar(false)}
+            severity={auth?.user ? 'success' : 'warning'}
+            sx={{ width: '100%' }}
+          >
+            {snackbarMessage}
+          </MuiAlert>
+        </Snackbar>
+      </Container>
     </Section>
   )
 }

--- a/src/components/PageHeading.tsx
+++ b/src/components/PageHeading.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { Box, BoxProps, Typography } from '@mui/material'
+
+export interface PageHeadingProps extends BoxProps {
+  headingText: string | React.ReactNode
+}
+
+export const PageHeading = ({
+  children = null,
+  headingText = '',
+  ...props
+}: PageHeadingProps) => (
+  <Box
+    alignItems="center"
+    component="header"
+    display="flex"
+    flexWrap="wrap"
+    gap="0.5rem"
+    justifyContent="flex-start"
+    margin="1rem 0 0.5rem"
+    {...props}
+  >
+    <Typography flexGrow="1" lineHeight="1.25" variant="h1">
+      {headingText}
+    </Typography>
+    {children}
+  </Box>
+)

--- a/src/components/PageHeading.tsx
+++ b/src/components/PageHeading.tsx
@@ -17,7 +17,8 @@ export const PageHeading = ({
     flexWrap="wrap"
     gap="0.5rem"
     justifyContent="flex-start"
-    margin="1rem 0 0.5rem"
+    margin="0.5rem 0"
+    minHeight="3.15rem"
     {...props}
   >
     <Typography flexGrow="1" lineHeight="1.25" variant="h1">

--- a/src/components/Settings/SettingsProfile.js
+++ b/src/components/Settings/SettingsProfile.js
@@ -6,7 +6,6 @@ import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemButton from '@mui/material/ListItemButton'
 import Container from '@mui/material/Container'
 import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
 import IconButton from '@mui/material/IconButton'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import DataUsageIcon from '@mui/icons-material/DataUsage'
@@ -20,6 +19,7 @@ import Stats from './SettingsStats'
 import { useAuth } from '../../util/auth'
 import { Link } from '../../util/router'
 import { useTranslation } from 'react-i18next'
+import { PageHeading } from 'components/PageHeading'
 
 function SettingsProfile() {
   const auth = useAuth()
@@ -57,9 +57,7 @@ function SettingsProfile() {
 
   return (
     <Container>
-      <Typography variant="h5" sx={{ fontWeight: '700' }}>
-        {user ? displayName : t('settings.profile')}
-      </Typography>
+      <PageHeading headingText={user ? displayName : t('settings.profile')} />
       <Box
         sx={{
           display: 'flex',

--- a/src/components/Settings/SettingsSection.js
+++ b/src/components/Settings/SettingsSection.js
@@ -72,8 +72,7 @@ function SettingsSection(props) {
           onDone={() => setReauthState({ show: false })}
         />
       )}
-
-      <Box mt={5} sx={{ paddingBottom: 15 }}>
+      <Box sx={{ paddingBottom: 15 }}>
         <Container maxWidth="850px" sx={{ padding: '0' }}>
           {formAlert && (
             <Box mb={4}>

--- a/src/components/Settings/SettingsStats.js
+++ b/src/components/Settings/SettingsStats.js
@@ -36,7 +36,7 @@ const Stats = () => {
     : []
 
   return (
-    <Box sx={{ padding: '40px 10px 10px 10px' }}>
+    <Box sx={{ padding: '10px' }}>
       <Grid container spacing={1} sx={{ width: '100%' }}>
         <Grid item xs={4}>
           <Box

--- a/src/components/SignUp/Progress.tsx
+++ b/src/components/SignUp/Progress.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { MobileStepper, Container, Link } from '@mui/material'
+import { MobileStepper, Container, Link, Typography } from '@mui/material'
 import ArrowBack from '@mui/icons-material/ArrowBack'
 import { SwiperNext, SwiperPrev } from './Swipers'
 import { useSwipe } from './Swipers'
@@ -39,10 +39,12 @@ export const ProgressBar = ({ start, end, slot }: ProgressProps) => {
           variant="subtitle1"
           underline="hover"
           p="0.75rem 1.5rem 0.75em 0"
-          display="block"
+          display="flex"
         >
-          Back to Dashboard
           <ArrowBack />
+          <Typography component="span" ml="0.5em">
+            Back to Dashboard
+          </Typography>
         </Link>
       ) : (
         <SwiperPrev handleClick={() => swiper.slidePrev()}>

--- a/src/components/auth/AuthSection.js
+++ b/src/components/auth/AuthSection.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import Container from '@mui/material/Container'
 import Section from '../Section'
-import SectionHeader from '../SectionHeader'
 import Auth from './Auth'
 import AuthFooter from './AuthFooter'
 import { useAuthTypeOptions } from '../../hooks/use-auth-type-options.hook'
+import { PageHeading } from 'components/PageHeading'
 
 function AuthSection({ bgColor, bgImage, bgImageOpacity, size }) {
   const { options } = useAuthTypeOptions()
@@ -17,12 +17,7 @@ function AuthSection({ bgColor, bgImage, bgImageOpacity, size }) {
       bgImageOpacity={bgImageOpacity}
     >
       <Container maxWidth="xs">
-        <SectionHeader
-          title={options.title}
-          subtitle=""
-          size={4}
-          textAlign="center"
-        />
+        <PageHeading headingText={options.title} textAlign="center" mb="2rem" />
         <Auth />
         <AuthFooter />
       </Container>


### PR DESCRIPTION
## Description

* [ClickUp ticket](https://app.clickup.com/t/9009201449/TIG-408)

This PR runs through the primary pages (Dashboard, Browse, My Courses, Profile) as well as various secondary templates (Course, Creator, Sign In, Create Account, etc.) to apply a consistent `PageHeading` component with an `h1` and set styling. 

The PR also includes various small tweaks for margin/padding sizing (mostly to keep the heading consistent) and repairing `img` `alt` text in a few spots as issues were encountered. 

## Screenshots

![image](https://github.com/heynovaio/create-to-learn/assets/1672105/4038ccbd-c229-4e60-a1e5-5925efc0504e)
![image](https://github.com/heynovaio/create-to-learn/assets/1672105/9d9b1079-485c-4df6-8af2-6ead6db54308)
![image](https://github.com/heynovaio/create-to-learn/assets/1672105/c45c9b85-defb-4e4f-abdb-873c6e481cea)
![image](https://github.com/heynovaio/create-to-learn/assets/1672105/fe9310af-2025-4643-abb6-9e460dafa62c)
![image](https://github.com/heynovaio/create-to-learn/assets/1672105/be248730-b5ef-4a07-a280-07c11a332c8b)
![image](https://github.com/heynovaio/create-to-learn/assets/1672105/580e20f3-20c2-4c9f-a801-7965ca2c5058)
![image](https://github.com/heynovaio/create-to-learn/assets/1672105/e218e6a9-a516-428c-b4ca-41b985462de1)
![image](https://github.com/heynovaio/create-to-learn/assets/1672105/5e640452-5c0b-4535-805c-0165102a03a3)
